### PR TITLE
CI: Fix package installation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install PostgreSQL
         run: |
+          sudo apt-get update
           # If needed, uninstall PostgreSQL v14 that GitHub supplies
           if test "${{ matrix.postgresql }}" != 14; then
               sudo pg_dropcluster 14 main --stop


### PR DESCRIPTION
Need to run `apt-get update` before installing to ensure up to date metadata, otherwise downloads can fail with 404.

Error from job output with PostgreSQL v14:

```
The following NEW packages will be installed:
  postgresql-server-dev-14
0 upgraded, 1 newly installed, 0 to remove and 21 not upgraded.
Need to get 1174 kB of archives.
After this operation, 6786 kB of additional disk space will be used.
Ign:1 http://azure.archive.ubuntu.com/ubuntu jammy-updates/universe amd64 postgresql-server-dev-14 amd64 14.7-0ubuntu0.22.04.1
Err:1 http://azure.archive.ubuntu.com/ubuntu jammy-updates/universe amd64 postgresql-server-dev-14 amd64 14.7-0ubuntu0.22.04.1
  404  Not Found [IP: 40.81.13.82 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/universe/p/postgresql-14/postgresql-server-dev-14_14.7-0ubuntu0.22.04.1_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```
